### PR TITLE
Set default tox posargs.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ install_command = pip install -r requirements.txt -U {opts} {packages}
 commands =
     coverage erase
     rm -fR .coverage .coverage.*
-    py.test --cov=python_course_1604 --cov-report term-missing --cov-report html --cov-report xml {posargs}
+    py.test --cov=python_course_1604 --cov-report term-missing --cov-report html --cov-report xml {posargs:python_course_1604}
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
This fixes problems with tests found on garbage directories like .eggs/
